### PR TITLE
Change way of creating bundle resources.

### DIFF
--- a/src/AppSvcsBuilder.py
+++ b/src/AppSvcsBuilder.py
@@ -520,11 +520,15 @@ class AppSvcsBuilder:
 			if filetype == "irule" and data.endswith('\n') == False:
 				print "  Adding newline to end of file..."
 				data += '\n';
+			
+			data = base64.b64encode(data)
+
+			data = '\\\n'.join(data[pos:pos+60] for pos in xrange(0, len(data), 60))
 
 			resources.append({
 				"key":key,
 				"ver":apm_bip_version[0],
-				"data":base64.b64encode(data)
+				"data":data
 				})
 
 		#self._debug("resources=%s" % resources)
@@ -536,6 +540,9 @@ class AppSvcsBuilder:
 
 		for r in resources:
 			fh.write("set bundler_data(%s) {%s}\n" % (r["key"], r["data"]))
+
+		for r in resources:
+			fh.write("regsub -all {\s} $bundler_data(%s) {} bundler_data(%s)\n" % (r["key"], r["key"]))
 
 		fh.close()
 


### PR DESCRIPTION
@KrystianMarek @0xHiteshPatel 

#### What issues does this address?
Fixes #29 
...

#### What's this change do?

Fix: Brake long string, generated by encoding raw data, by
adding new line with special character \ which in TCL is
the brake line character. After that TCL change new line to space
in long string. Next all bundled resources are deprived of withspace
characters.

#### Where should the reviewer start?

Build iapp with bundled APM and ASM policies (./build -b test/bundled.test) and import to iWorkflow.

#### Any background context?

Problem: When user build template with bundled resources
like iRules, APM politics and ASM politics, then iWorkflow
can't import such iApp.
