### PR TITLE
change sample_defaults to inherit deviceGroup

### DIFF
--- a/scripts/deploy_iapp_samples/sample_defaults.json
+++ b/scripts/deploy_iapp_samples/sample_defaults.json
@@ -3,9 +3,9 @@
 	"password":"admin",
 	"template_name":"latest",
 	"inheritedDevicegroup": "true",
-    "deviceGroup": "none",
+    "deviceGroup": "default",
     "inheritedTrafficGroup": "true",
-    "trafficGroup": "/Common/traffic-group-local-only",
+    "trafficGroup": "/Common/traffic-group-1",
     "partition":"Common",
 	"strings":[
 		{ "iapp__strictUpdates":"enabled" },


### PR DESCRIPTION
#### What issues does this address?
When deploying to a standalone device it will use "/Common/traffic-group-local-only".  This creates an issue if you have already created a Virtual Server that uses the same IP (virtual-address will have different trafficGroup).  I believe that this change provides safer behavior.  include_defaults.json also uses the same settings so it may require changing as well.
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?

