### PR TITLE
Revert "Remove app_stats from presentation layer."

### DIFF
--- a/src/presentation_layer.json
+++ b/src/presentation_layer.json
@@ -36,6 +36,17 @@
 					"minver":"0.3_001"
 				},
 				{
+					"name":"appStats",
+					"description":"iApp: Statistics Handler Creation",
+					"help":"Control whether Virtual Server/Pool statistics handlers are created in Standalone or iWorkflow mode",
+					"type":"boolean",
+					"default":true,
+					"required":false,
+					"display":"large",
+					"modes":[1,2],
+					"minver":"0.3_001"
+				},
+				{
 					"name":"mode",
 					"description":"iApp: Mode",
 					"help":"The mode to use during deployment.  The default setting of auto determines the mode automatically.",


### PR DESCRIPTION
This reverts commit 4b43965fdfab7fc0d710ad3a2e280ffbb69f0469.


In the presentation layer there isn't any app_stats var. I miss understand it and I reverting appStats (iapp__appStats). 