### PR TITLE
Move iapp_safe_display method the the iApp.

### DIFF
--- a/build.py
+++ b/build.py
@@ -69,6 +69,11 @@ args.outfile = 'parts' + os.sep + 'iapp.apl'
 args.roottmpl = 'tmp' + os.sep + 'apl.build'
 b.buildTemplate(**vars(args))
 
+print "Assembling CLI script only template..."
+args.outfile = 'parts' + os.sep + 'appsvcs.integration.util.tcl'
+args.roottmpl = 'src' + os.sep + 'outside_util.tcl'
+b.buildTemplate(**vars(args))
+
 print "Generating BIGIP JSON template..."
 b.buildJsonTemplate()
 

--- a/scripts/README.import_template_bigip
+++ b/scripts/README.import_template_bigip
@@ -18,6 +18,7 @@ look in the current working directory for the following files:
  iapp.apl		Presentation Layer APL Code	YES	  -a
  iapp.html		HTML based Help			NO	  -n
  iapp.macro		iApp Macro definition		NO	  -m
+ iapp_util.tcl  CLI script              NO    -s
 
 Different filenames can be specified using the corresponding CLI arguments 
 in the table above 
@@ -29,6 +30,8 @@ If you are specifying the require TMOS modules please format as a comma
 seperated list of module names such as:
  
 	ltm,gtm,asm,afm
+
+If you want to import CLI script the script name need to be set.
 
 For further options please run the script with the --help argument
 

--- a/src/AppSvcsBuilder.py
+++ b/src/AppSvcsBuilder.py
@@ -332,7 +332,7 @@ class AppSvcsBuilder:
 	      }
 	    }
 
-        return [iapp::safe_display ::choices]
+        return [tmsh::run_proc appsvcs.integration.util:iapp_safe_display ::choices]
 	}
 		""" % ' '.join(field["create_list"])
 

--- a/src/master.template
+++ b/src/master.template
@@ -1,12 +1,8 @@
-cli admin-partitions {
-    update-partition Common
-}
-
 cli script appsvcs.integration.util {
 %insertfile:src/outside_util.tcl%
 }
 
-sys application template /Common/appsvcs_integration_v%IMPLVERSION_MAJOR%.%IMPLVERSION_MINOR%%NAME_APPEND% {
+sys application template appsvcs_integration_v%IMPLVERSION_MAJOR%.%IMPLVERSION_MINOR%%NAME_APPEND% {
     actions {
         definition {
             html-help {
@@ -39,12 +35,7 @@ sys application template /Common/appsvcs_integration_v%IMPLVERSION_MAJOR%.%IMPLV
             run-as none
         }
     }
-    description none
-    ignore-verification false
     requires-bigip-version-max none
     requires-bigip-version-min none
     requires-modules { ltm }
-    signing-key none
-    tmpl-checksum none
-    tmpl-signature none
 }

--- a/src/master.template
+++ b/src/master.template
@@ -1,6 +1,11 @@
 cli admin-partitions {
     update-partition Common
 }
+
+cli script appsvcs.integration.util {
+%insertfile:src/outside_util.tcl%
+}
+
 sys application template /Common/appsvcs_integration_v%IMPLVERSION_MAJOR%.%IMPLVERSION_MINOR%%NAME_APPEND% {
     actions {
         definition {

--- a/src/outside_util.tcl
+++ b/src/outside_util.tcl
@@ -1,0 +1,9 @@
+proc iapp_safe_display { args } {
+  # strings sent to APL must be truncated to 65535 bytes, see BZ435592
+  if { [string length [set [set args]]] > 65535 } {
+    set last_newline [string last "\n" [set [set args]] 65500]
+    return "[string range [set [set args]] 0 $last_newline]Error: Too many items for display"
+  } else {
+    return [set [set args]]
+  }
+}


### PR DESCRIPTION
@AGrzes @KrystianMarek @0xHiteshPatel 

#### What issues does this address?
Fixes BZ668496

#### What's this change do?
This change introduce method iapp_safe_display which are present only
in BIG-IP 12.1.0 and up. From now iapp creates cli script that include
mentioned method. The APL choice menu now call this new cli script
rather than rely on existnce iapp_safe_display method.


#### Where should the reviewer start?
Using BIG-IP 12.0.0 or older import iapp:
- using UI
- using import_template_bigip.py
Then using UI create new instance of iapp.

#### Any background context?
In v2.0.004 there is problem with iapp_safe_display method which doesn't exist as a standard procedure.