### PR TITLE
Missing vs  name

### DIFF
--- a/src/util.tcl
+++ b/src/util.tcl
@@ -223,7 +223,7 @@ proc change_var { name value } {
   lappend ::postfinal_deferred_cmds "if { \$\:\:errorCode != \"\" && \[regexp \"was not found\" \$err\] } {"
   lappend ::postfinal_deferred_cmds [create_escaped_tmsh [format "tmsh::modify sys application service %s/%s variables add \{ %s \{ value \"%s\" \} \}" $::app_path $::app $name $value]]
   lappend ::postfinal_deferred_cmds "} elseif { \$\:\:errorCode != \"\" } {"
-  lappend ::postfinal_deferred_cmds [format "    puts \"Error while tring modify %s with value %s error is msg -> \$err\"" $name $value ]
+  lappend ::postfinal_deferred_cmds [format "    puts \"Error while trying modify %s with value %s error is msg -> \$err\"" $name $value ]
   lappend ::postfinal_deferred_cmds "}"
   set [subst ::$name] $value
   set ::aso_config($name) $value

--- a/test/test_without_vs__Name.json
+++ b/test/test_without_vs__Name.json
@@ -1,0 +1,123 @@
+{
+    "name":"test_without_vs__Name",
+	"username":"admin",
+	"password":"admin",
+	"template_name":"latest",
+	"inheritedDevicegroup": "true",
+    "deviceGroup": "none",
+    "inheritedTrafficGroup": "true",
+    "trafficGroup": "/Common/traffic-group-local-only",
+    "partition":"Common",
+	"strings":[
+		{ "iapp__strictUpdates":"enabled" },
+		{ "iapp__appStats":"enabled" },
+		{ "iapp__mode":"auto" },
+		{ "iapp__logLevel":"10" },
+		{ "iapp__routeDomain":"auto" },
+    	{ "iapp__asmDeployMode":"preserve-bypass" },
+    	{ "iapp__apmDeployMode":"preserve-bypass" },
+		{ "pool__addr":"0.0.0.0" },
+		{ "pool__mask":"0.0.0.0" },
+		{ "pool__port":"0" },
+		{ "pool__DefaultPoolIndex":"0" },
+		{ "pool__MemberDefaultPort":"80" },
+		{ "vs__Description":"" },
+		{ "vs__SourceAddress":"0.0.0.0/0" },
+		{ "vs__IpProtocol":"any" },
+		{ "vs__ConnectionLimit":"0" },
+		{ "vs__ProfileClientProtocol":"fastL4" },
+		{ "vs__ProfileServerProtocol":"" },
+		{ "vs__ProfileHTTP":"" },
+		{ "vs__ProfileOneConnect":"" },
+		{ "vs__ProfileCompression":"" },
+		{ "vs__ProfileAnalytics":"" },
+		{ "vs__ProfileRequestLogging":"" },
+		{ "vs__ProfileDefaultPersist":"" },
+		{ "vs__ProfileFallbackPersist":"" },
+		{ "vs__SNATConfig":"automap" },
+		{ "vs__ProfileServerSSL":"" },
+		{ "vs__ProfileClientSSL":"" },
+		{ "vs__ProfileClientSSLCert":"" },
+		{ "vs__ProfileClientSSLKey":"" },
+		{ "vs__ProfileClientSSLChain":"" },
+		{ "vs__ProfileClientSSLCipherString":"DEFAULT" },
+		{ "vs__ProfileClientSSLAdvOptions":"" },
+		{ "vs__ProfileSecurityLogProfiles":"" },
+		{ "vs__ProfileSecurityIPBlacklist":"none" },
+		{ "vs__ProfileSecurityDoS":"" },
+		{ "vs__ProfileAccess":"" },
+		{ "vs__ProfileConnectivity":"" },
+		{ "vs__ProfilePerRequest":"" },
+		{ "vs__OptionSourcePort":"preserve" },
+		{ "vs__OptionConnectionMirroring":"disabled" },
+		{ "vs__Irules":"" },
+		{ "vs__AdvOptions":"" },
+		{ "vs__AdvProfiles":"" },
+		{ "vs__AdvPolicies":"" },
+        { "vs__RouteAdv":"disabled" },
+        { "vs__VirtualAddrAdvOptions":"" },
+		{ "l7policy__strategy":"/Common/first-match"},
+		{ "l7policy__defaultASM":"bypass"},
+		{ "l7policy__defaultL7DOS":"bypass"},
+		{ "feature__statsTLS":"auto" },
+		{ "feature__statsHTTP":"auto" },
+		{ "feature__insertXForwardedFor":"auto" },
+		{ "feature__redirectToHTTPS":"auto" },
+		{ "feature__sslEasyCipher":"disabled" },
+		{ "feature__securityEnableHSTS":"disabled" },
+		{ "feature__easyL4Firewall":"disabled" },
+		{ "extensions__Field1":"" },
+		{ "extensions__Field2":"" },
+		{ "extensions__Field3":"" }
+	],
+	"tables":[
+		{
+			"name":"pool__Pools",
+			"columnNames": [ "Index", "Name", "Description", "LbMethod", "Monitor", "AdvOptions" ],
+			"rows" : [
+			]
+		},
+		{
+			"name":"pool__Members",
+			"columnNames": [ "Index", "IPAddress", "Port", "ConnectionLimit", "Ratio", "PriorityGroup", "State", "AdvOptions" ],
+			"rows" : [ ]		
+		},
+		{
+			"name":"monitor__Monitors",
+			"columnNames": ["Index", "Name", "Type", "Options"],
+			"rows" : [ 
+			]
+		},
+		{
+			"name":"vs__Listeners",
+			"columnNames": ["Listener"],
+			"rows" : [ ]
+		},
+		{
+			"name":"vs__BundledItems",
+			"columnNames": ["Resource"],
+			"rows" : [ ]
+		},		
+		{
+			"name":"l7policy__rulesMatch",
+			"columnNames": ["Index","Operand","Negate","Condition","Value","CaseSensitive","Missing"],
+			"rows" : [ ]
+		},
+		{
+			"name":"l7policy__rulesAction",
+			"columnNames": ["Index","Target","Parameter"],
+			"rows" : [ ]
+		},
+		{
+			"name":"feature__easyL4FirewallBlacklist",
+			"columnNames": [ "CIDRRange" ],
+			"rows" : [ ]		
+		},		
+		{
+			"name":"feature__easyL4FirewallSourceList",
+			"columnNames": [ "CIDRRange" ],
+			"rows" : [ ]
+        }		
+	],
+	"lists": [ ]
+}


### PR DESCRIPTION
@0xHiteshPatel @KrystianMarek @AGrzes 

#### What issues does this address?
Fixes #46 

...

#### What's this change do?
Wraps tmsh::modify with try catch. If error isn't found, then postdeploy_final will try the same command, but will use operand add.

#### Where should the reviewer start?
Run test_without_vs__Name test on old version and see error on script.out file mentioned in #46. After creation goto tmui and see in reconfigure tab there is empty "Virtual Server: Name" box.

Then run the same test agains this change. The script.out file will not have errors. Tmui on the other hand will have "Virtual Server: Name" box filed.

#### Any background context?
If user wants to create simple iApp but omit vs__name in rest request, then iApp will create vs__Name by herself. The problem is when user want to reconfigure the iApp, but "Virtual Server: Name" is empty.