### PR TITLE
Workaround mcpd race condition

### DIFF
--- a/scripts/deploy_iapp_bigip.py
+++ b/scripts/deploy_iapp_bigip.py
@@ -118,7 +118,7 @@ def check_final_deploy(istat_key):
 	current_time = int(time.time())
 	bashurl   = "https://%s/mgmt/tm/util/bash" % (args.host)
 	istat_payload = { "command":"run",
-					 "utilCmdArgs":"-c 'tmsh run cli script appsvcs_get_istat \"%s\"'" % (istat_key)
+					 "utilCmdArgs":"-c 'istats get \"%s\"'" % (istat_key)
 	               }
 
 	for i in range(args.checknum):

--- a/src/implementation_layer.tcl
+++ b/src/implementation_layer.tcl
@@ -2122,7 +2122,7 @@ if { $bundler_all_deploy } {
   debug [list bundler icall_src] [format "%s" $bundler_icall_src] 10
   debug [list bundler icall_handler] [format "creating iCall handler; executing postdeploy script at: %s" $bundler_icall_time] 7
 
-  tmsh::create sys icall script postdeploy_bundler definition \{ $postfinal_icall_src \}
+  tmsh::create sys icall script postdeploy_bundler definition \{ $bundler_icall_src \}
   tmsh::create sys icall handler periodic postdeploy_bundler interval 10 first-occurrence $bundler_icall_time last-occurrence $bundler_icall_time script postdeploy_bundler status active
 
   debug [list bundler deploy] "Bundled policy deployment will complete momentarily..." 5

--- a/src/include/postdeploy_bundler.icall
+++ b/src/include/postdeploy_bundler.icall
@@ -150,7 +150,7 @@ foreach df $dellist {
 }
 
 tmsh::delete sys icall handler periodic postdeploy_bundler
-tmsh::modify sys icall handler periodic postdeploy_final first-occurrence now status active
+tmsh::create sys icall handler periodic postdeploy_final interval 10 first-occurrence now last-occurrence now script postdeploy_final status active
 if { $strict_updates eq "enabled" } {
 	tmsh::modify sys application service $aso strict-updates enabled
 }

--- a/src/include/postdeploy_bundler.icall
+++ b/src/include/postdeploy_bundler.icall
@@ -1,6 +1,3 @@
-sys icall script %APP_PATH%/postdeploy_bundler {
-    app-service %APP_PATH%/%APP_NAME%
-    definition {
 set app %APP_NAME%
 set app_path %APP_PATH%
 set partition %PARTITION%
@@ -161,16 +158,3 @@ if { $strict_updates eq "enabled" } {
 set systemTime [clock seconds]
 puts "$logprefix Finished at [clock format $systemTime -format %D] [clock format $systemTime -format %H:%M:%S]"
 istats::set [format "%s string deploy.postdeploy_bundler" $iaso] "FINISHED"
-    }
-    description none
-    events none
-}
-
-sys icall handler periodic %APP_PATH%/postdeploy_bundler {
-    app-service %APP_PATH%/%APP_NAME%
-    first-occurrence %ICALLTIME%
-    interval 3000
-    last-occurrence now+10m
-    script %APP_PATH%/postdeploy_bundler
-    status active
-}

--- a/src/include/postdeploy_final.icall
+++ b/src/include/postdeploy_final.icall
@@ -1,6 +1,3 @@
-sys icall script %APP_PATH%/postdeploy_final {
-    app-service %APP_PATH%/%APP_NAME%
-    definition {
 set app %APP_NAME%
 set app_path %APP_PATH%
 set partition %PARTITION%
@@ -37,35 +34,3 @@ if { $strict_updates eq "enabled" } {
 set systemTime [clock seconds]
 puts "$logprefix Finished at [clock format $systemTime -format %D] [clock format $systemTime -format %H:%M:%S]"
 istats::set [format "%s string deploy.postdeploy_final" $iaso] [format "FINISHED_%s" $systemTime]
-    }
-    description none
-    events none
-}
-
-sys icall handler periodic %APP_PATH%/postdeploy_final {
-    app-service %APP_PATH%/%APP_NAME%
-    first-occurrence %ICALLTIME%
-    interval 3000
-    last-occurrence now+10m
-    script %APP_PATH%/postdeploy_final
-    status %HANDLER_STATE%
-}
-
-cli script /Common/appsvcs_get_istat {
-proc script::init {} {
-}
-
-proc script::run {} {
-    if { $tmsh::argc < 2 } {
-        puts "Please specify a iStat key to get"
-        exit
-    }
-    puts [istats::get [lindex $tmsh::argv 1]]
-}
-
-proc script::help {} {
-}
-
-proc script::tabc {} {
-}
-}


### PR DESCRIPTION
#### What's this change do?

Remove appsvcs_get_istat cli script from verification proces. Now the
istats program is called to verify if deploy.postdeploy_fina is set to
FINISED_TIMESTAMP.

Periodic hanlders are now created inside iApp. This commit remove
creation of 2 files in /var/tmp/ directory. The logic that loads
postdeploy icall script is changed to utilize transactions inside iApp.

@0xHiteshPatel @KrystianMarek @AGrzes @lukesiler

#### What issues does this address?
FIX BZ-659304
...

#### Any background context?
The timeout in [line 2202](https://github.com/F5Networks/f5-application-services-integration-iApp/blob/f35957a157256fb62d792c7f86601d415c45559b/src/implementation_layer.tcl#L2202) in some rare circumstance is not enough.