### PR TITLE
Function tmsh load now is in new icall script.

### DIFF
--- a/src/include/tmsh_load.icall
+++ b/src/include/tmsh_load.icall
@@ -1,0 +1,22 @@
+set app %APP_NAME%
+set app_path %APP_PATH%
+set partition %PARTITION%
+set vs_name %VS_NAME%
+set strict_updates %STRICTUPDATES%
+
+set aso "/$partition/${app}.app/$app"
+set iaso [format "sys.application.service %s" $aso]
+set logprefix "\[appsvcs_postdeploy_final\]\[$app\]"
+set filename [format "/var/tmp/appsvcs_postdeploy_%s.conf" $app]
+
+if { [file exists $filename] } {
+    tmsh::cd $app_path
+    tmsh::modify sys application service $aso strict-updates disabled
+
+    tmsh::load sys config file $filename merge
+    file delete -force $filename
+
+    if { $strict_updates eq "enabled" } {
+    	tmsh::modify sys application service $aso strict-updates enabled
+    }
+}

--- a/src/resources/implementation_layer.tcl
+++ b/src/resources/implementation_layer.tcl
@@ -2162,10 +2162,13 @@ set postfinal_icall_tmpl {
 };
 
 set postfinal_handler_state "inactive"
+# If bundling proces is not required, then delay of post final iCall script is lower by factor POSTDEPLOY_DELAY. 
 if { $postdeploy_final_state } {
   set postfinal_handler_state "active"
+  # The delay for post final iCall script is set to 16 seconds.
   set postfinal_icall_time [clock format [expr {[clock seconds] + $::POSTDEPLOY_DELAY*2}] -format {%Y-%m-%d:%H:%M:%S}]
 } else {
+  # The delay for post final iCall script is set to 24 seconds.
   set postfinal_icall_time [clock format [expr {[clock seconds] + $::POSTDEPLOY_DELAY*3}] -format {%Y-%m-%d:%H:%M:%S}]
 }
 
@@ -2199,7 +2202,7 @@ catch {
 } {}
 
 set tmsh_load_icall_tmpl {
-%insertfile:src/include/tmsh_load.icall%
+%insertfile:include/tmsh_load.icall%
 };
 
 set tmsh_load_icall_time [clock format [expr {[clock seconds] + $::POSTDEPLOY_DELAY}] -format {%Y-%m-%d:%H:%M:%S}]

--- a/src/resources/include/postdeploy_bundler.icall
+++ b/src/resources/include/postdeploy_bundler.icall
@@ -62,6 +62,9 @@ foreach policy $asm_policy_list {
 	istats::set [format "%s string deploy.postdeploy_bundler.asm.%s" $iaso $policy] "DEPLOY_IN_PROGRESS"
 	set policy_filename [format "/var/tmp/appsvcs_asm_%s_%s_%s.xml" $app $policy $timestamp]
 	puts "$logprefix Loading ASM policy from $policy_filename to ASO $aso..."
+	if { $newdeploy } {
+	    tmsh::create asm policy $policy
+	}
 	tmsh::load asm policy $policy file $policy_filename overwrite
 	tmsh::modify asm policy $policy app-service $aso
 

--- a/src/resources/include/postdeploy_final.icall
+++ b/src/resources/include/postdeploy_final.icall
@@ -50,22 +50,3 @@ sys icall handler periodic %APP_PATH%/postdeploy_final {
     script %APP_PATH%/postdeploy_final
     status %HANDLER_STATE%
 }
-
-cli script /Common/appsvcs_get_istat {
-proc script::init {} {
-}
-
-proc script::run {} {
-    if { $tmsh::argc < 2 } {
-        puts "Please specify a iStat key to get"
-        exit
-    }
-    puts [istats::get [lindex $tmsh::argv 1]]
-}
-
-proc script::help {} {
-}
-
-proc script::tabc {} {
-}
-}

--- a/src/resources/include/tmsh_load.icall
+++ b/src/resources/include/tmsh_load.icall
@@ -11,11 +11,15 @@ set filename [format "/var/tmp/appsvcs_postdeploy_%s.conf" $app]
 
 if { [file exists $filename] } {
     tmsh::cd $app_path
+    # The strict-updates must be disabled on iApp due to fact any modification outside
+    # iApp platform is blocked. There is no checking if previous state was disabled or
+    # enalbed, because this will be waste of one operation.
     tmsh::modify sys application service $aso strict-updates disabled
 
     tmsh::load sys config file $filename merge
     file delete -force $filename
 
+    tmsh::delete sys icall handler periodic tmsh_load_icall
     if { $strict_updates eq "enabled" } {
     	tmsh::modify sys application service $aso strict-updates enabled
     }


### PR DESCRIPTION
@lukesiler @KrystianMarek @AGrzes @0xHiteshPatel 

#### What issues does this address?

#### What's this change do?
Change call sequence when iApp is created. First iApp is creaded with 2 icall script publish_stats and tmsh_load. Second tmsh_load icall polling for /var/tmp/appsvcs_postdeploy_%s.conf file. Where %s is the name of the iApp. Third postdeploy_bundle icall script is call if appropriate fields was send. Fourth post deploy_final icall end the whole process.


#### Any background context?
