### PR TITLE
Workaround mcpd race condition

### DIFF
--- a/src/appservices/BIPClient.py
+++ b/src/appservices/BIPClient.py
@@ -152,7 +152,7 @@ class BIPClient(object):
 
         current_time = int(time.time())
         istat_key = self._get_istat_key(payload['partition'], payload['name'])
-        command = 'tmsh run cli script appsvcs_get_istat \"{}\"'.format(
+        command = 'istats get \"{}\"'.format(
             istat_key)
 
         for check_run in range(max_check):

--- a/src/resources/implementation_layer.tcl
+++ b/src/resources/implementation_layer.tcl
@@ -2122,7 +2122,7 @@ if { $bundler_all_deploy } {
   debug [list bundler icall_src] [format "%s" $bundler_icall_src] 10
   debug [list bundler icall_handler] [format "creating iCall handler; executing postdeploy script at: %s" $bundler_icall_time] 7
 
-  tmsh::create sys icall script postdeploy_bundler definition \{ $postfinal_icall_src \}
+  tmsh::create sys icall script postdeploy_bundler definition \{ $bundler_icall_src \}
   tmsh::create sys icall handler periodic postdeploy_bundler interval 10 first-occurrence $bundler_icall_time last-occurrence $bundler_icall_time script postdeploy_bundler status active
 
   debug [list bundler deploy] "Bundled policy deployment will complete momentarily..." 5

--- a/src/resources/implementation_layer.tcl
+++ b/src/resources/implementation_layer.tcl
@@ -2157,6 +2157,12 @@ set postfinal_icall_tmpl {
 %insertfile:include/postdeploy_final.icall%
 };
 
+set postfinal_handler_state "inactive"
+
+if { $postdeploy_final_state } {
+  set postfinal_handler_state "active"
+}
+
 set postfinal_deferred_cmds_str [join $postfinal_deferred_cmds "\n"]
 
 set postfinal_icall_time [clock format [expr {[clock seconds] + $::POSTDEPLOY_DELAY}] -format {%Y-%m-%d:%H:%M:%S}]
@@ -2175,9 +2181,7 @@ debug [list postfinal icall_src] [format "%s" $postfinal_icall_src] 10
 debug [list postfinal icall_handler] [format "creating iCall handler; executing postdeploy_final script at: %s" $postfinal_icall_time] 7
 
 tmsh::create sys icall script postdeploy_final definition \{ $postfinal_icall_src \}
-if { $postdeploy_final_state } {
-    tmsh::create sys icall handler periodic postdeploy_final script postdeploy_final interval 10 first-occurrence $postfinal_icall_time last-occurrence $postfinal_icall_time status active
-}
+tmsh::create sys icall handler periodic postdeploy_final script postdeploy_final interval 10 first-occurrence $postfinal_icall_time last-occurrence $postfinal_icall_time status $postfinal_handler_state
 
 if { $iapp__strictUpdates eq "disabled" } {
   debug [list strict_updates] "disabling strict updates" 5

--- a/src/resources/implementation_layer.tcl
+++ b/src/resources/implementation_layer.tcl
@@ -22,7 +22,7 @@ set TMPLNAME "%TMPL_NAME%"
 set IMPLMAJORVERSION "2.0"
 set IMPLMINORVERSION "004"
 set IMPLVERSION [format "%s.%s" $IMPLMAJORVERSION $IMPLMINORVERSION]
-set POSTDEPLOY_DELAY 0
+set POSTDEPLOY_DELAY 5
 
 if { [tmsh::get_field_value [lindex [tmsh::get_config sys scriptd log-level] 0] log-level] eq "debug" } {
   set iapp__logLevel 10
@@ -2123,7 +2123,7 @@ if { $bundler_all_deploy } {
   debug [list bundler icall_handler] [format "creating iCall handler; executing postdeploy script at: %s" $bundler_icall_time] 7
 
   tmsh::create sys icall script postdeploy_bundler definition \{ $postfinal_icall_src \}
-  tmsh::create sys icall handler periodic postdeploy_bundler interval 60 script postdeploy_bundler
+  tmsh::create sys icall handler periodic postdeploy_bundler interval 10 first-occurrence $bundler_icall_time last-occurrence $bundler_icall_time script postdeploy_bundler status active
 
   debug [list bundler deploy] "Bundled policy deployment will complete momentarily..." 5
 }
@@ -2157,11 +2157,6 @@ set postfinal_icall_tmpl {
 %insertfile:include/postdeploy_final.icall%
 };
 
-set postfinal_handler_state "inactive"
-if { $postdeploy_final_state } {
-  set postfinal_handler_state "active"
-}
-
 set postfinal_deferred_cmds_str [join $postfinal_deferred_cmds "\n"]
 
 set postfinal_icall_time [clock format [expr {[clock seconds] + $::POSTDEPLOY_DELAY}] -format {%Y-%m-%d:%H:%M:%S}]
@@ -2173,14 +2168,16 @@ set postfinal_script_map [list %APP_NAME%  $::app \
                      %NEWDEPLOY%     $newdeploy \
                      %REDEPLOY%      $redeploy \
                      %DEFERREDCMDS%  $postfinal_deferred_cmds_str \
-                     %STRICTUPDATES% $iapp__strictUpdates \
-                     %HANDLER_STATE% $postfinal_handler_state ]
+                     %STRICTUPDATES% $iapp__strictUpdates ]
 
 set postfinal_icall_src [string map $postfinal_script_map $postfinal_icall_tmpl]
 debug [list postfinal icall_src] [format "%s" $postfinal_icall_src] 10
 debug [list postfinal icall_handler] [format "creating iCall handler; executing postdeploy_final script at: %s" $postfinal_icall_time] 7
+
 tmsh::create sys icall script postdeploy_final definition \{ $postfinal_icall_src \}
-tmsh::create sys icall handler periodic postdeploy_final interval 60 script postdeploy_final status $postfinal_handler_state
+if { $postdeploy_final_state } {
+    tmsh::create sys icall handler periodic postdeploy_final script postdeploy_final interval 10 first-occurrence $postfinal_icall_time last-occurrence $postfinal_icall_time status active
+}
 
 if { $iapp__strictUpdates eq "disabled" } {
   debug [list strict_updates] "disabling strict updates" 5

--- a/src/resources/include/postdeploy_bundler.icall
+++ b/src/resources/include/postdeploy_bundler.icall
@@ -150,7 +150,7 @@ foreach df $dellist {
 }
 
 tmsh::delete sys icall handler periodic postdeploy_bundler
-tmsh::modify sys icall handler periodic postdeploy_final first-occurrence now status active
+tmsh::create sys icall handler periodic postdeploy_final interval 10 first-occurrence now last-occurrence now script postdeploy_final status active
 if { $strict_updates eq "enabled" } {
 	tmsh::modify sys application service $aso strict-updates enabled
 }

--- a/src/resources/include/postdeploy_bundler.icall
+++ b/src/resources/include/postdeploy_bundler.icall
@@ -1,6 +1,3 @@
-sys icall script %APP_PATH%/postdeploy_bundler {
-    app-service %APP_PATH%/%APP_NAME%
-    definition {
 set app %APP_NAME%
 set app_path %APP_PATH%
 set partition %PARTITION%
@@ -161,16 +158,3 @@ if { $strict_updates eq "enabled" } {
 set systemTime [clock seconds]
 puts "$logprefix Finished at [clock format $systemTime -format %D] [clock format $systemTime -format %H:%M:%S]"
 istats::set [format "%s string deploy.postdeploy_bundler" $iaso] "FINISHED"
-    }
-    description none
-    events none
-}
-
-sys icall handler periodic %APP_PATH%/postdeploy_bundler {
-    app-service %APP_PATH%/%APP_NAME%
-    first-occurrence %ICALLTIME%
-    interval 3000
-    last-occurrence now+10m
-    script %APP_PATH%/postdeploy_bundler
-    status active
-}

--- a/src/resources/include/postdeploy_bundler.icall
+++ b/src/resources/include/postdeploy_bundler.icall
@@ -150,7 +150,7 @@ foreach df $dellist {
 }
 
 tmsh::delete sys icall handler periodic postdeploy_bundler
-tmsh::create sys icall handler periodic postdeploy_final interval 10 first-occurrence now last-occurrence now script postdeploy_final status active
+tmsh::modify sys icall handler periodic postdeploy_final interval 10 first-occurrence now last-occurrence now script postdeploy_final status active
 if { $strict_updates eq "enabled" } {
 	tmsh::modify sys application service $aso strict-updates enabled
 }

--- a/src/resources/include/postdeploy_final.icall
+++ b/src/resources/include/postdeploy_final.icall
@@ -1,6 +1,3 @@
-sys icall script %APP_PATH%/postdeploy_final {
-    app-service %APP_PATH%/%APP_NAME%
-    definition {
 set app %APP_NAME%
 set app_path %APP_PATH%
 set partition %PARTITION%
@@ -37,35 +34,3 @@ if { $strict_updates eq "enabled" } {
 set systemTime [clock seconds]
 puts "$logprefix Finished at [clock format $systemTime -format %D] [clock format $systemTime -format %H:%M:%S]"
 istats::set [format "%s string deploy.postdeploy_final" $iaso] [format "FINISHED_%s" $systemTime]
-    }
-    description none
-    events none
-}
-
-sys icall handler periodic %APP_PATH%/postdeploy_final {
-    app-service %APP_PATH%/%APP_NAME%
-    first-occurrence %ICALLTIME%
-    interval 3000
-    last-occurrence now+10m
-    script %APP_PATH%/postdeploy_final
-    status %HANDLER_STATE%
-}
-
-cli script /Common/appsvcs_get_istat {
-proc script::init {} {
-}
-
-proc script::run {} {
-    if { $tmsh::argc < 2 } {
-        puts "Please specify a iStat key to get"
-        exit
-    }
-    puts [istats::get [lindex $tmsh::argv 1]]
-}
-
-proc script::help {} {
-}
-
-proc script::tabc {} {
-}
-}


### PR DESCRIPTION
#### What's this change do?

Remove appsvcs_get_istat cli script from verification proces. Now the
istats program is called to verify if deploy.postdeploy_fina is set to
FINISED_TIMESTAMP.

Periodic hanlders are now created inside iApp. This commit remove
creation of 2 files in /var/tmp/ directory **appsvcs_postdeploy_NAME_OF_IAPP.conf** and **appsvcs_load_postdeploy_NAME_OF_IAPP.sh**. The logic that loads
postdeploy icall script is changed to utilize transactions inside iApp.
The order of call script should be:

1. postdeploy_bundler
2. postdeploy_final

If postdeoloy_bundler is not applicable then only postdeploy_final icall script should be called.

@0xHiteshPatel @KrystianMarek @AGrzes @lukesiler

#### What issues does this address?
FIX BZ-659304
...

#### Any background context?
The timeout in [line 2202](https://github.com/F5Networks/f5-application-services-integration-iApp/blob/f35957a157256fb62d792c7f86601d415c45559b/src/implementation_layer.tcl#L2202) in some rare circumstance is not enough.