### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,92 +19,31 @@
 Application Services Integration iApp 
 =========================================================
 
-|travis build|
+**This AS2 GitHub repository has been archived and is read-only.
+The AS2 project is no longer actively maintained.**
 
-.. _Documentation: https://devcentral.f5.com/wiki/iApp.AppSvcsiApp_index.ashx
+Application Services 3 Extension (AS3) is now available at https://github.com/F5Networks/f5-appsvcs-extension
 
-**ATTENTION**: Application Services 3 Extension (AS3) is now available at https://github.com/F5Networks/f5-appsvcs-extension 
-
-AS3 is an F5-supported solution which will replace the App Services iApp 2.x (a traditional TCL iApp). 
+AS3 is an F5-supported solution which replaces the App Services iApp 2.x (a traditional TCL iApp).
 
 AS3 is built on our extensible programmability framework called iControl LX.
 
-**The App Services iApp 2.x GitHub repository will be archived later this year.**
-
-Moving forward, please use AS3 for all new App Services automation use cases.
+Please use AS3 for all new App Services automation use cases.
 
 
-Introduction
-------------
-
-The purpose of this project is to provide an iApp template that can be used to automate and orchestrate Layer 4-7 applications service deployments using F5 Networks BIG-IP/iWorkflow Products. Additionally, this template serves as a common integration point for third party SDN/NFV/Automation/Orchestration products.
-
-Documentation
--------------
-
-Please refer to the F5 App Services Integration iApp `project documentation <https://devcentral.f5.com/wiki/iApp.AppSvcsiApp_index.ashx>`_ for detailed information.
-
-
-TMOS Version Support
---------------------
-Application Services Integration iApp 2.x has been tested against the following versions of TMOS:
-- 11.5
-- 11.6
-- 12.0
-- 12.1
-
-Application Services Integration iApp 2.x not supported on TMOS 13.x.
-
-Release
----------
-
-To download the latest release click `here <https://github.com/F5Networks/f5-application-services-integration-iApp/releases>`_
-
-Filing Issues
--------------
-
-If you find an issue, we would love to hear about it. Please let us know by filing an `issue <https://github.com/F5Networks/f5-application-services-integration-iApp/issues>`_ in this repository. Use the issue template to tell us as much as you can about what you found, how you found it, your environment, etc.. We also welcome you to file feature requests as issues.
-
-Contributing
-------------
-
-See `Contributing <https://github.com/F5Networks/f5-application-services-integration-iApp/blob/release/v2.0.002/CONTRIBUTING.md>`_.
-
-Copyright
----------
-
-Copyright 2015-2017 F5 Networks Inc.
 
 Support
--------
-
-See `Support <https://github.com/F5Networks/f5-application-services-integration-iApp/blob/release/v2.0.002/SUPPORT.rst>`_.
+See [Support](https://github.com/F5Networks/f5-application-services-integration-iApp/blob/release/v2.0.002/SUPPORT.rst).
 
 License
--------
-
 Apache V2.0
-~~~~~~~~~~~
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may
-not use this file except in compliance with the License. You may obtain
-a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-Contributor License Agreement
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Individuals or business entities who contribute to this project must
-have completed and submitted the `F5 Contributor License
-Agreement <https://github.com/F5Networks/f5-application-services-integration-iApp/raw/release/v2.0.002/docs/_static/F5-contributor-license-agreement.pdf>`_
-to cla@f5.com prior to their code submission being included
-in this project.
+
 
 .. |travis build| image:: https://travis-ci.org/F5Networks/f5-application-services-integration-iApp.svg?branch=master
     :target: https://travis-ci.org/F5Networks/f5-application-services-integration-iApp


### PR DESCRIPTION
With the stable release of AS3, AS2 is being archived and is no longer supported.  Updating README to reflect this.

@JosephPJordan 

#### What issues does this address?
AS2 is being archived
...

#### What's this change do?
Updates README to reflect the archiving of AS2 and indicates it is is no longer supported.

#### Where should the reviewer start?

#### Any background context?

